### PR TITLE
Update AGENTS docs for Python 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@ This repository contains the NEXD 1D solver, a Fortran project built with a Make
 - `src/include/` – additional Fortran utilities and modules
 - `simulations/` – example simulation setups
 - `Makefile` – build rules for the solver and analytical program
-- `makeDepFromUseInclude.py` – script to generate module dependencies for Makefile (Python 2 style)
+- `makeDepFromUseInclude.py` – script to generate module dependencies for Makefile (Python 3)
 
 ## Building
 Run `make all` to build the main solver. `make analytical` builds the analytical solver. The build expects
 `gfortran`, `mpif90`, `lapack`, `blas`, `pgplot`, and `tcsh` to be available. The Makefile uses `makeDepFromUseInclude.py`
-to generate dependency information; this script requires Python 2 or adaptation to Python 3.
+ to generate dependency information; this script is written for Python 3.
 
 ## Tests
 There are currently no automated tests. To verify the build, run `make all` which should compile the solver


### PR DESCRIPTION
## Summary
- document that `makeDepFromUseInclude.py` is a Python 3 script

## Testing
- `./setup.sh`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_688512277c8083268b96d362a9207401