### PR TITLE
Add pFUnit test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,12 @@ This repository contains the NEXD 1D solver, a Fortran project built with a Make
 ## Building
 Run `make all` to build the main solver. `make analytical` builds the analytical solver. The build expects
 `gfortran`, `mpif90`, `lapack`, `blas`, `pgplot`, and `tcsh` to be available. The Makefile uses `makeDepFromUseInclude.py`
- to generate dependency information; this script is written for Python 3.
+to generate dependency information; this script is written for Python 3.
 
 ## Tests
-There are currently no automated tests. To verify the build, run `make all` which should compile the solver
-and produce a binary in `bin/`. If compilation fails due to missing dependencies, run `setup.sh` in the project
-root to install them on Debian/Ubuntu systems.
-
+Unit tests use the pFUnit framework. Install pFUnit and set the `PFUNIT` variable to its install directory.
+Run `make test` to build and execute the test suite in `tests/`.
+If compilation fails due to missing dependencies, run `setup.sh` in the project root to install them on Debian/Ubuntu systems.
 
 ## Updating instructions
 Ensure any changes to project guidelines are reflected in this file. Always update AGENTS.md when instructions change.

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ bindir = ./bin
 obsdir = ./obj
 moduledir = ./mod
 srcdir = ./src
+PFUNIT ?= /usr/local/pfunit
 AR = ar
 
 # Choose your compiler:
@@ -128,6 +129,7 @@ obj_solver = \
 	rhsSlipInterface1DMod.o \
 	errorMessage.o \
 	realloc.o \
+        ioMod.o \
 	sourcesMod.o \
 	slipInterfaceMod.o \
 	genericMaterial.o \
@@ -146,7 +148,8 @@ obj_analyticalSol = \
 	slipInterfaceMod.o \
 	errorMessage.o \
 	materials1DMod.o \
-	realloc.o
+	realloc.o \
+        ioMod.o
 	
 obj_test = testprogramm.o \
 #-------------------------------------------------------
@@ -216,9 +219,9 @@ solver: $(obj_solver)
 analytical: $(obj_analyticalSol)
 	$(gf) $(FFLAGS) -o $(bindir)/$@ $(obstring) $(la)
 	
-test: $(obj_test)
-	$(gf) $(FFLAGS) -o $(bindir)/$@ $(obstring) $(la)
-	
+test:
+	$(MAKE) -C tests PFUNIT=$(PFUNIT)
+
 bin:
 	mkdir -p $(bindir)
 #

--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ NEXD 1D comes with three examples: an example for elastic wave propagation (simu
      make all
      ```
    from installation path `NEXD-1D/` to compile NEXD 1D.
+
+## Running Tests
+
+Install pFUnit and set the `PFUNIT` variable to its installation directory. Then run
+
+```
+make test
+```
+
+This compiles and executes the test suite located in `tests/`.
+

--- a/src/include/ioMod.f90
+++ b/src/include/ioMod.f90
@@ -1,0 +1,36 @@
+! Simple I/O utilities for reading and writing vectors
+module ioMod
+  use constantsMod
+  implicit none
+contains
+  subroutine writeVector(filename, vec)
+    character(len=*), intent(in) :: filename
+    real(kind=custom_real), dimension(:), intent(in) :: vec
+    integer :: unit, i
+    open(newunit=unit, file=filename, status='replace', action='write')
+    do i = 1, size(vec)
+      write(unit,*) vec(i)
+    end do
+    close(unit)
+  end subroutine writeVector
+
+  function readVector(filename) result(vec)
+    character(len=*), intent(in) :: filename
+    real(kind=custom_real), allocatable :: vec(:)
+    integer :: unit, n, i
+    real(kind=custom_real) :: tmp
+    n = 0
+    open(newunit=unit, file=filename, status='old', action='read')
+    do
+      read(unit,*,end=10) tmp
+      n = n + 1
+    end do
+10  continue
+    rewind(unit)
+    allocate(vec(n))
+    do i = 1, n
+      read(unit,*) vec(i)
+    end do
+    close(unit)
+  end function readVector
+end module ioMod

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,26 @@
+PFUNIT ?= /usr/local/pfunit
+include $(PFUNIT)/include/PFUNIT.mk
+
+FC ?= gfortran
+FFLAGS += -I../src -I../src/include $(PFUNIT_EXTRA_FFLAGS)
+
+unit_tests_TESTS := test_getgll.pf test_io.pf
+unit_tests_OTHER_SOURCES := \
+    ../src/constantsMod.f90 \
+    ../src/include/realloc.f90 \
+    ../src/include/errorMessage.f90 \
+    test_parameterMod.f90 \
+    ../src/gllMod.f90 \
+    ../src/include/ioMod.f90
+
+$(eval $(call make_pfunit_test,unit_tests))
+
+all: unit_tests
+
+%.o: %.F90
+	$(FC) -c $(FFLAGS) $< -o $@
+
+%.o: %.f90
+	$(FC) -c $(FFLAGS) $< -o $@
+test_getgll.o test_io.o: $(unit_tests_other_objs)
+../src/gllMod.o: ../src/constantsMod.o

--- a/tests/test_getgll.pf
+++ b/tests/test_getgll.pf
@@ -1,0 +1,19 @@
+module test_getgll
+  use pfunit
+  use gllMod
+  use parameterMod
+  use constantsMod
+contains
+@test
+  subroutine test_order4()
+    type(meshVar) :: mesh
+    real(kind=custom_real), dimension(:), allocatable :: result
+    mesh%np = 5
+    result = getGll(mesh)
+    call assertEqual(1.0_custom_real, result(1), tolerance=1e-6_custom_real)
+    call assertEqual(0.6546536707079771_custom_real, result(2), tolerance=1e-6_custom_real)
+    call assertEqual(0.0_custom_real, result(3), tolerance=1e-6_custom_real)
+    call assertEqual(-0.6546536707079771_custom_real, result(4), tolerance=1e-6_custom_real)
+    call assertEqual(-1.0_custom_real, result(5), tolerance=1e-6_custom_real)
+  end subroutine
+end module

--- a/tests/test_io.pf
+++ b/tests/test_io.pf
@@ -1,0 +1,15 @@
+module test_io
+  use pfunit
+  use ioMod
+  use constantsMod
+contains
+@test
+  subroutine test_write_read()
+    real(kind=custom_real), dimension(3) :: x = (/1.0_custom_real, 2.0_custom_real, 3.0_custom_real/)
+    real(kind=custom_real), dimension(:), allocatable :: y
+    character(len=*), parameter :: fname = 'tmp_vector.dat'
+    call writeVector(fname, x)
+    y = readVector(fname)
+    call assertEqual(x, y, tolerance=1e-12_custom_real)
+  end subroutine
+end module

--- a/tests/test_parameterMod.f90
+++ b/tests/test_parameterMod.f90
@@ -1,0 +1,5 @@
+module parameterMod
+  type :: meshVar
+     integer :: np
+  end type meshVar
+end module parameterMod


### PR DESCRIPTION
## Summary
- create ioMod for simple vector IO
- add pFUnit-based test suite for gllMod and ioMod
- integrate pFUnit in Makefile and document usage
- mention tests in AGENTS guidelines

## Testing
- `make -C tests PFUNIT=/tmp/pfunit/build/installed/PFUNIT-4.12 FC=gfortran unit_tests`
- `./tests/unit_tests`

------
https://chatgpt.com/codex/tasks/task_e_6887a5ceaf2c832691fe185cb968ac9e